### PR TITLE
Fix a tiny bug in solver.py

### DIFF
--- a/python/triqs_ctint/solver.py
+++ b/python/triqs_ctint/solver.py
@@ -137,7 +137,8 @@ class Solver(SolverCore):
                         # Sig_HF[bl1][idx_u4, idx_u1] -= coef * G_dens[bl3][u2, u3]
                         # Sig_HF[bl3][idx_u2, idx_u3] -= coef * G_dens[bl1][u4, u1]
             
-                return Sig_HF_flat - flatten(list(Sig_HF.items()))
+                Sig_HF_ordered = [[bl, Sig_HF[bl]] for bl, idx_lst in gf_struct]
+                return Sig_HF_flat - flatten(Sig_HF_ordered)
             
             # Invoke the root finder
             Sig_HF_init = [[bl, np.zeros((len(idx_lst), len(idx_lst)))] for bl, idx_lst in gf_struct]


### PR DESCRIPTION
In `solver.py`, I think there is a small bug in the part solving the mean-field equations. In order for `flatten` and `unflatten` to be compatible, the argument of `flatten` must be in the order specified by `gf_struct`. `Sig_HF.items()` can return the elements of `Sig_HF` in an undefined order (it can be a dictionary) at least for python before 3.6 (after 3.6 the elements of a dict are insertion ordered). I see the bug happening in python 3.5.1.