### PR TITLE
Add auto_corr_time as a read-only member to Solver

### DIFF
--- a/python/triqs_ctint/solver_core_desc.py
+++ b/python/triqs_ctint/solver_core_desc.py
@@ -47,6 +47,11 @@ c.add_member(c_name = "average_k",
              read_only= True,
              doc = r"""Average perturbation order""")
 
+c.add_member(c_name = "auto_corr_time",
+             c_type = "double",
+             read_only= True,
+             doc = r"""Auto-correlation time""")
+
 c.add_member(c_name = "histogram",
              c_type = "std::optional<std::vector<double> >",
              read_only= True,


### PR DESCRIPTION
This was forgotten in #11 because we couldn't use `c++2py` to generate the `solver_core.desc.py` file.

First `c++2py` couldn't find the MPI header files
```console
$ c++2py ../../c++/triqs_ctint/solver_core.hpp --members_read_only -N triqs_ctint -a triqs_ctint -m solver_core -o solver_core -C triqs --moduledoc="The TRIQS ctint solver" --includes="../../c++" --cxxflags="-std=c++17" --target_file_only
Welcome to C++2py
Parsing the C++ file (may take a few seconds) ...
Traceback (most recent call last):
  File "/home/og85ixak/Code/triqs/triqs/install/bin/c++2py", line 64, in <module>
    W= Cpp2Desc(filename = args.filename, 
  File "/home/og85ixak/Code/triqs/triqs/install/lib/python3.8/site-packages/cpp2py/cpp2desc.py", line 86, in __init__
    self.root = CL.parse(filename, compiler_options, includes, system_includes, libclang_location, parse_all_comments)
  File "/home/og85ixak/Code/triqs/triqs/install/lib/python3.8/site-packages/cpp2py/clang_parser.py", line 444, in parse
    raise RuntimeError(s + "\n... Your code must compile before using clang-parser !")
RuntimeError: Clang reports the following errors in parsing
 file /usr/include/mpi/mpi.hpp line 19 col 10
'mpi.h' file not found
... Your code must compile before using clang-parser !
```
and after telling it about the location it failed with
```console
$ CPLUS_INCLUDE_PATH=/usr/lib/x86_64-linux-gnu/openmpi/include:$CPLUS_INCLUDE_PATH c++2py ../../c++/triqs_ctint/solver_core.hpp --members_read_only -N triqs_ctint -a triqs_ctint -m solver_core -o solver_core -C triqs --moduledoc="The TRIQS ctint solver" --includes="../../c++" --cxxflags="-std=c++17" --target_file_only
Welcome to C++2py
Parsing the C++ file (may take a few seconds) ...
Traceback (most recent call last):
  File "/home/og85ixak/Code/triqs/triqs/install/bin/c++2py", line 64, in <module>
    W= Cpp2Desc(filename = args.filename, 
  File "/home/og85ixak/Code/triqs/triqs/install/lib/python3.8/site-packages/cpp2py/cpp2desc.py", line 86, in __init__
    self.root = CL.parse(filename, compiler_options, includes, system_includes, libclang_location, parse_all_comments)
  File "/home/og85ixak/Code/triqs/triqs/install/lib/python3.8/site-packages/cpp2py/clang_parser.py", line 444, in parse
    raise RuntimeError(s + "\n... Your code must compile before using clang-parser !")
RuntimeError: Clang reports the following errors in parsing
 file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/macros.hpp line 40 col 32
redefinition of 'remove_cv_ref' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/macros.hpp line 43 col 10
redefinition of 'is_view_tag' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/macros.hpp line 44 col 32
redefinition of 'is_view' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/factory.hpp line 28 col 34
redefinition of 'factories' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/factory.hpp line 32 col 34
redefinition of 'factories<std::vector<T>>' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/factory.hpp line 61 col 44
redefinition of 'factory' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 29 col 35
redefinition of '_triqs_zipped_tuple' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 37 col 54
redefinition of 'zip_tuples' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 44 col 47
redefinition of 'tuple_size<triqs::_triqs_zipped_tuple<T0, T...>>' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 46 col 53
redefinition of 'get' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 51 col 33
redefinition of '_triqs_reversed_tuple' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 53 col 68
redefinition of 'reverse' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 54 col 70
redefinition of 'reverse' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 55 col 76
redefinition of 'reverse' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 57 col 50
redefinition of 'get' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 61 col 50
redefinition of 'get' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 65 col 50
redefinition of 'get' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 69 col 32
redefinition of 'tuple_size<_triqs_reversed_tuple<TU>>' file /home/og85ixak/Code/triqs/triqs/install/include/triqs/utility/tuple_tools.hpp line 76 col 93
redefinition of '_get_seq' file None line 0 col 0
too many errors emitted, stopping now
... Your code must compile before using clang-parser !
```