### PR TITLE
Fix runaway memory in G2c_from_M4

### DIFF
--- a/c++/triqs_ctint/post_process.cpp
+++ b/c++/triqs_ctint/post_process.cpp
@@ -4,38 +4,43 @@
 
 namespace triqs_ctint {
 
-  chi4_iw_t G2c_from_M4(chi4_iw_t::const_view_type M4_iw, g_iw_t::const_view_type M_iw, g_iw_t::const_view_type G0_iw) {
+  chi4_iw_t G2c_from_M4(chi4_iw_t::const_view_type M4_iw, g_iw_t::const_view_type M_iw, g_iw_t::const_view_type G0_iw,
+                        mpi::communicator const &comm) {
 
-    double beta  = M_iw[0].domain().beta;
-    int n_blocks = M_iw.size();
+    chi4_iw_t G2c_iw = M4_iw; // FIXME Product Ranges with += Lazy Expressions
 
-    // Calculate connected part of M4
-    chi4_iw_t M4_iw_conn = M4_iw;
+    if (comm.rank() == 0) {
+      double beta  = M_iw[0].domain().beta;
+      int n_blocks = M_iw.size();
 
-    for (int bl1 : range(n_blocks))
-      for (int bl2 : range(n_blocks))
-        M4_iw_conn(bl1, bl2)(iw1_, iw2_, iw3_)(i_, j_, k_, l_) << M4_iw(bl1, bl2)(iw1_, iw2_, iw3_)(i_, j_, k_, l_)
-              - beta * kronecker(iw1_, iw2_) * M_iw[bl1](iw1_)(j_, i_) * M_iw[bl2](iw3_)(l_, k_)
-              + beta * kronecker(bl1, bl2) * kronecker(iw2_, iw3_) * M_iw[bl1](iw1_)(l_, i_) * M_iw[bl2](iw3_)(j_, k_);
+      // Calculate connected part of M4
+      chi4_iw_t M4_iw_conn = M4_iw;
 
-    // Calculate disconnected part of the two-particle Green function
-    chi4_iw_t G2c_iw = M4_iw_conn; // FIXME Product Ranges with += Lazy Expressions
-    G2c_iw()         = 0.;
+      for (int bl1 : range(n_blocks))
+        for (int bl2 : range(n_blocks))
+          M4_iw_conn(bl1, bl2)(iw1_, iw2_, iw3_)(i_, j_, k_, l_) << M4_iw(bl1, bl2)(iw1_, iw2_, iw3_)(i_, j_, k_, l_)
+                - beta * kronecker(iw1_, iw2_) * M_iw[bl1](iw1_)(j_, i_) * M_iw[bl2](iw3_)(l_, k_)
+                + beta * kronecker(bl1, bl2) * kronecker(iw2_, iw3_) * M_iw[bl1](iw1_)(l_, i_) * M_iw[bl2](iw3_)(j_, k_);
 
-    for (int bl1 : range(n_blocks))
-      for (int bl2 : range(n_blocks)) {
+      // Calculate disconnected part of the two-particle Green function
+      G2c_iw() = 0.;
 
-        int bl1_size = M4_iw(bl1, bl2).target_shape()[0];
-        int bl2_size = M4_iw(bl1, bl2).target_shape()[2];
+      for (int bl1 : range(n_blocks))
+        for (int bl2 : range(n_blocks)) {
 
-        for (int m : range(bl1_size))
-          for (int n : range(bl1_size))
-            for (int o : range(bl2_size))
-              for (int p : range(bl2_size))
-                G2c_iw(bl1, bl2)(iw1_, iw2_, iw3_)(i_, j_, k_, l_) << G2c_iw(bl1, bl2)(iw1_, iw2_, iw3_)(i_, j_, k_, l_)
-                      + G0_iw[bl1](iw2_)(j_, n) * G0_iw[bl2](iw1_ - iw2_ + iw3_)(l_, p) * M4_iw_conn(bl1, bl2)(iw1_, iw2_, iw3_)(m, n, o, p)
-                         * G0_iw[bl1](iw1_)(m, i_) * G0_iw[bl2](iw3_)(o, k_);
-      }
+          int bl1_size = M4_iw(bl1, bl2).target_shape()[0];
+          int bl2_size = M4_iw(bl1, bl2).target_shape()[2];
+
+          for (int m : range(bl1_size))
+            for (int n : range(bl1_size))
+              for (int o : range(bl2_size))
+                for (int p : range(bl2_size))
+                  G2c_iw(bl1, bl2)(iw1_, iw2_, iw3_)(i_, j_, k_, l_) << G2c_iw(bl1, bl2)(iw1_, iw2_, iw3_)(i_, j_, k_, l_)
+                        + G0_iw[bl1](iw2_)(j_, n) * G0_iw[bl2](iw1_ - iw2_ + iw3_)(l_, p) * M4_iw_conn(bl1, bl2)(iw1_, iw2_, iw3_)(m, n, o, p)
+                           * G0_iw[bl1](iw1_)(m, i_) * G0_iw[bl2](iw3_)(o, k_);
+        }
+    }
+    mpi::broadcast(G2c_iw, comm);
 
     return G2c_iw;
   }

--- a/c++/triqs_ctint/post_process.hpp
+++ b/c++/triqs_ctint/post_process.hpp
@@ -5,7 +5,7 @@
 namespace triqs_ctint {
 
   /// Calculate the connected part of the two-particle Green function from M4_iw and M_iw
-  chi4_iw_t G2c_from_M4(chi4_iw_t::const_view_type M4_iw, g_iw_cv_t M_iw, g_iw_cv_t G0_iw);
+  chi4_iw_t G2c_from_M4(chi4_iw_t::const_view_type M4_iw, g_iw_cv_t M_iw, g_iw_cv_t G0_iw, mpi::communicator const &comm);
 
   /// Calculate the vertex function $F$ from G2c_iw and G_iw
   chi4_iw_t F_from_G2c(chi4_iw_t::const_view_type G2c_iw, g_iw_cv_t G_iw);

--- a/c++/triqs_ctint/solver_core.cpp
+++ b/c++/triqs_ctint/solver_core.cpp
@@ -260,7 +260,7 @@ namespace triqs_ctint {
     }
 
     // Calculate G2c_iw, F_iw and G2_iw from M4_iw and M_iw
-    if (M4_iw and M_iw) G2c_iw = G2c_from_M4(M4_iw.value(), M_iw.value(), G0_shift_iw);
+    if (M4_iw and M_iw) G2c_iw = G2c_from_M4(M4_iw.value(), M_iw.value(), G0_shift_iw, world);
     if (G2c_iw and M_iw) F_iw = F_from_G2c(G2c_iw.value(), G_iw);
     if (G2c_iw and M_iw) G2_iw = G2_from_G2c(G2c_iw.value(), G_iw);
 

--- a/python/triqs_ctint/post_process_desc.py
+++ b/python/triqs_ctint/post_process_desc.py
@@ -6,7 +6,7 @@ from cpp2py.wrap_generator import *
 module = module_(full_name = "post_process", doc = r"The TRIQS ctint postprocess functionality", app_name = "triqs_ctint")
 
 # Imports
-module.add_imports(*['triqs.gf', 'triqs.operators'])
+module.add_imports(*['triqs.gf', 'triqs.gf.meshes', 'triqs.operators', 'triqs.utility.mpi'])
 
 # Add here all includes
 module.add_include("triqs_ctint/post_process.hpp")
@@ -15,10 +15,9 @@ module.add_include("triqs_ctint/post_process.hpp")
 module.add_preamble("""
 #include <cpp2py/converters/complex.hpp>
 #include <cpp2py/converters/pair.hpp>
+#include <cpp2py/converters/std_array.hpp>
 #include <cpp2py/converters/string.hpp>
-#include <cpp2py/converters/variant.hpp>
 #include <cpp2py/converters/vector.hpp>
-#include <triqs/cpp2py_converters/arrays.hpp>
 #include <triqs/cpp2py_converters/gf.hpp>
 #include <triqs/cpp2py_converters/operators_real_complex.hpp>
 #include <triqs/cpp2py_converters/real_or_complex.hpp>
@@ -27,13 +26,13 @@ using namespace triqs_ctint;
 """)
 
 
-module.add_function ("triqs_ctint::chi4_iw_t triqs_ctint::G2c_from_M4 (chi4_iw_t::view_type M4_iw, triqs_ctint::g_iw_cv_t M_iw, triqs_ctint::g_iw_cv_t G0_iw)", doc = r"""Calculate the connected part of the two-particle Green function from M4_iw and M_iw""")
+module.add_function ("triqs_ctint::chi4_iw_t triqs_ctint::G2c_from_M4 (chi4_iw_t::view_type M4_iw, triqs_ctint::g_iw_cv_t M_iw, triqs_ctint::g_iw_cv_t G0_iw, mpi::communicator comm)", doc = r"""Calculate the connected part of the two-particle Green function from M4_iw and M_iw""")
 
 module.add_function ("triqs_ctint::chi4_iw_t triqs_ctint::F_from_G2c (chi4_iw_t::view_type G2c_iw, triqs_ctint::g_iw_cv_t G_iw)", doc = r"""Calculate the vertex function :math:`F` from G2c_iw and G_iw""")
 
 module.add_function ("triqs_ctint::chi4_iw_t triqs_ctint::G2_from_G2c (chi4_iw_t::view_type G2c_iw, triqs_ctint::g_iw_cv_t G_iw)", doc = r"""Calculate the two-particle Green function from G2c_iw and G_iw""")
 
-module.add_function ("triqs_ctint::chi4_iw_t triqs_ctint::chi_tilde_ph_from_G2c (chi4_iw_t::view_type G2c_iw, triqs_ctint::g_iw_cv_t G_iw, triqs::hilbert_space::gf_struct_t gf_struct)", doc = r"""Calculate the generalized ph susceptibility from G2c_iw and G_iw""")
+module.add_function ("triqs_ctint::chi4_iw_t triqs_ctint::chi_tilde_ph_from_G2c (chi4_iw_t::view_type G2c_iw, triqs_ctint::g_iw_cv_t G_iw, triqs::gfs::gf_struct_t gf_struct)", doc = r"""Calculate the generalized ph susceptibility from G2c_iw and G_iw""")
 
 module.add_function ("triqs_ctint::chi3_iw_t triqs_ctint::chi3_from_M3_PP (triqs_ctint::chi3_iw_cv_t M3_iw, triqs_ctint::g_iw_cv_t M_iw, triqs_ctint::g_iw_cv_t G0_iw, triqs_ctint::block_matrix_t dens_G, triqs_ctint::block_matrix_t M_hartree)", doc = r"""""")
 
@@ -43,9 +42,9 @@ module.add_function ("triqs_ctint::chi2_tau_t triqs_ctint::chi2_from_chi2_conn_P
 
 module.add_function ("triqs_ctint::chi2_tau_t triqs_ctint::chi2_from_chi2_conn_PH (triqs_ctint::chi2_tau_cv_t chi2_conn_tau, triqs_ctint::g_iw_cv_t G_iw, triqs_ctint::block_matrix_t dens_G)", doc = r"""""")
 
-module.add_function ("gf<triqs::gfs::imtime, triqs::gfs::matrix_valued> triqs_ctint::chiAB_from_chi2_PP (triqs_ctint::chi2_tau_cv_t chi2pp_tau, triqs::hilbert_space::gf_struct_t gf_struct, std::vector<many_body_operator> A_op_vec, std::vector<many_body_operator> B_op_vec)", doc = r"""""")
+module.add_function ("gf<triqs::mesh::imtime, triqs::gfs::matrix_valued> triqs_ctint::chiAB_from_chi2_PP (triqs_ctint::chi2_tau_cv_t chi2pp_tau, triqs::gfs::gf_struct_t gf_struct, std::vector<many_body_operator> A_op_vec, std::vector<many_body_operator> B_op_vec)", doc = r"""""")
 
-module.add_function ("gf<triqs::gfs::imtime, triqs::gfs::matrix_valued> triqs_ctint::chiAB_from_chi2_PH (triqs_ctint::chi2_tau_cv_t chi2ph_tau, triqs::hilbert_space::gf_struct_t gf_struct, std::vector<many_body_operator> A_op_vec, std::vector<many_body_operator> B_op_vec)", doc = r"""""")
+module.add_function ("gf<triqs::mesh::imtime, triqs::gfs::matrix_valued> triqs_ctint::chiAB_from_chi2_PH (triqs_ctint::chi2_tau_cv_t chi2ph_tau, triqs::gfs::gf_struct_t gf_struct, std::vector<many_body_operator> A_op_vec, std::vector<many_body_operator> B_op_vec)", doc = r"""""")
 
 module.add_function ("triqs_ctint::chi2_tau_t triqs_ctint::chi2_conn_from_M3_PP (triqs_ctint::chi3_tau_t M3pp_tau, triqs_ctint::chi2_tau_t M3pp_delta, triqs_ctint::g_iw_cv_t M_iw, triqs_ctint::g_iw_cv_t G0_iw, triqs_ctint::g_tau_cv_t M_tau, triqs_ctint::block_matrix_t M_hartree, triqs_ctint::g_tau_cv_t G0_tau)", doc = r"""""")
 


### PR DESCRIPTION
The function `G2c_from_M4` computes the two-particle Green's function from the vertex for every rank which is redundant. Also this easily leads to memory exhaustion if all ranks are actually on the same physical node. The fix we propose here is rather ad-hoc. Ideally the calculation would avoid the temporary `M4_iw_conn` altogether, because `M4_iw` is by far the largest object in TRIQS so duplication should really be avoided.

Co-authored-by: @marcel-klett 