### PR TITLE
Enable D0_iw and Jperp_iw terms

### DIFF
--- a/test/python/dynamic/all.py
+++ b/test/python/dynamic/all.py
@@ -51,6 +51,8 @@ S.D0_iw['up','dn'][0,0]  << D**2*(inverse(iOmega_n-w0)-inverse(iOmega_n+w0))
 
 # --------- Solve! ----------
 S.solve(h_int=h_int,
+        alpha_mode = "trivial",
+        n_s = 2,
         n_cycles = n_cyc,
         length_cycle = 50,
         n_warmup_cycles = 100,

--- a/test/python/dynamic/densdens.py
+++ b/test/python/dynamic/densdens.py
@@ -46,6 +46,8 @@ S.D0_iw['up','dn'][0,0]  << D**2*(inverse(iOmega_n-w0)-inverse(iOmega_n+w0))
 
 # --------- Solve! ----------
 S.solve(h_int=h_int,
+        alpha_mode = "trivial",
+        n_s = 2,
         n_cycles = n_cyc,
         length_cycle = 50,
         n_warmup_cycles = 100,

--- a/test/python/dynamic/jperp.py
+++ b/test/python/dynamic/jperp.py
@@ -46,6 +46,8 @@ S.Jperp_iw[0,0] << 0.5 * J**2*(inverse(iOmega_n-w0)-inverse(iOmega_n+w0))
 
 # --------- Solve! ----------
 S.solve(h_int=h_int,
+        alpha_mode = "trivial",
+        n_s = 2,
         n_cycles = n_cyc,
         length_cycle = 50,
         n_warmup_cycles = 100,


### PR DESCRIPTION
This reenables the use of `D0_iw` terms and `Jperp_iw` terms with `DEV_NEW_ALPHA`. Unfortunately, the handling of the alpha tensor has changed quite significantly, so it's not possible to reproduce old test data.

Co-authored-by: @marcel-klett